### PR TITLE
Add ability to specify port

### DIFF
--- a/LethalSsh.cs
+++ b/LethalSsh.cs
@@ -57,10 +57,24 @@ public class LethalSsh : BaseUnityPlugin
             {
                 __result = ScriptableObject.CreateInstance<TerminalNode>();
                 __result.clearPreviousText = true;
+                string[] arg1;
                 switch (args.Length)
                 {
+                    case 4:
+                        arg1 = args[1].Split("@");
+                        if (arg1.Length != 2) {
+                            __result.displayText = "Invalid arguments";
+                            break;
+                        }
+                        int port = 22;
+                        Int32.TryParse(args[2], out port);
+                        LethalSsh.Instance.sshClient = new SshClient(arg1[1], port, arg1[0], args[3]);
+                        LethalSsh.Instance.sshClient.Connect();
+                        LethalSsh.Instance.sshShell = LethalSsh.Instance.sshClient.CreateShellStream("linux", 20, 20, 800, 600, 1024);
+                        __result.displayText = "";
+                        break;
                     case 3:
-                        string[] arg1 = args[1].Split("@");
+                        arg1 = args[1].Split("@");
                         if (arg1.Length != 2)
                         {
                             __result.displayText = "Invalid arguments";

--- a/README.md
+++ b/README.md
@@ -6,4 +6,10 @@ Please report any issues on [GitHub](https://github.com/baerchen201/LethalSSHPlu
 
 adds ssh to the terminal
 
-Usage: ssh \<username\>@\<host\> \<password\>
+Usage:
+
+`ssh \<username\>@\<host\> \<password\>`
+
+or
+
+`ssh \<username\>@\<host\> \<port\> \<password\>`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ adds ssh to the terminal
 
 Usage:
 
-`ssh \<username\>@\<host\> \<password\>`
+`ssh <username>@<host> <password>`
 
 or
 
-`ssh \<username\>@\<host\> \<port\> \<password\>`
+`ssh <username>@<host> <port> <password>`


### PR DESCRIPTION
Adds the option to provide a port in the command. As documented in the README, syntax for port is `ssh <user>@<host> <port> <password>`